### PR TITLE
feat : 호버 효과 적용(마우스 올릴 시 "자세히 보기" 칸 출력)

### DIFF
--- a/frontend/src/components/cards/missionCard/SmallMissionCard.js
+++ b/frontend/src/components/cards/missionCard/SmallMissionCard.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import '../../../css/common.css'
 import missionImageExample from '../../../images/missionExample.jpeg';
 
@@ -8,14 +8,24 @@ const SmallMissionCard = (props) => {
 
     return <>
         <div className={'smallMissionView'}>
+
             <div className={'smallMissionCardTitle'}>
                 {missionName}
             </div>
-            <div className={'smallMissionImageMask'}>
-                <img className={'smallMissionImage'}
-                     src={missionImageExample}
-                     alt={null}/>
-            </div>
+            <ul>
+                <li>
+                    <a href="#">
+                        <figure>
+                            <div className={'smallMissionImageMask'}>
+                                <img className={'smallMissionImage'}
+                                    src={missionImageExample}
+                                    alt={null} />
+                            </div>
+                            <figcaption>자세히보기</figcaption>
+                        </figure>
+                    </a>
+                </li>
+            </ul>
         </div>
     </>
 }

--- a/frontend/src/components/cards/successCard/SmallSuccessCard.js
+++ b/frontend/src/components/cards/successCard/SmallSuccessCard.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import '../../../css/common.css'
 
 const SmallSuccessCard = (props) => {
@@ -6,17 +6,25 @@ const SmallSuccessCard = (props) => {
     const [imageSrc, setImageSrc] = useState(props.image);
 
     const getImage = () => {
-      return imageSrc ? imageSrc : null;
+        return imageSrc ? imageSrc : null;
     }
 
     return <>
         <div className={'smallSuccessView'}>
-            <div className={'smallSuccessImageMask'}>
-                <img className={'smallSuccessImage'}
-                     src={getImage()}
-                     alt={null}/>
-            </div>
-
+            <ul>
+                <li>
+                    <a href="#">
+                        <figure>
+                            <div className={'smallSuccessImageMask'}>
+                                <img className={'smallSuccessImage'}
+                                    src={getImage()}
+                                    alt={null} />
+                            </div>
+                            <figcaption>자세히보기</figcaption>
+                        </figure>
+                    </a>
+                </li>
+            </ul>
             <div className={'smallSuccessCardContent'}>
                 {successContent}
             </div>

--- a/frontend/src/css/common.css
+++ b/frontend/src/css/common.css
@@ -45,6 +45,59 @@ html {
     box-shadow: 4px 4px 4px 0 rgba(0, 0, 0, 0.25);
 }
 
+/* 호버 여기부터 */
+*{ padding: 0; margin: 0; }
+li{ list-style: none; }
+
+  .smallMissionView li{
+    float: left;
+    width: 146px; height: 146px;
+    /* margin-right: 20px; */
+  }
+  .smallMissionView li:last-child{ margin-right: 0; }
+  
+  .smallMissionView a{
+    display: block; /* 영역적용위해 사용 */
+    width: 100%; height: 100%;
+    overflow: hidden; /* 넘어가는 자손을 안보이게 처리 */
+    position: relative; /* figcaption의 앱솔루트 기준을 현재 요소로 변경 */
+  }
+  
+  .smallMissionView figcaption{
+    width: 100%; height: 100%;
+    background-color: rgba(0,0,0,0.2);
+    color: #fff; text-align: center;
+    line-height: 150px;
+    font-size:10px;
+    position: absolute; /* 기본기준 : body */
+    top: 0; left: 0;
+    opacity: 0; /* 처음에 안보이게 처리 */
+    transition: 0.3s; /* 변화되는 CSS에 시간차를 줌 */
+  }
+  
+  /* 테두리 */
+  .smallMissionView figcaption:after{
+    content: ''; /* 비워둠 */
+    display: block;
+    width: calc(100% - 15px);
+    height: calc(100% - 15px);
+    border: 1px solid #fff;
+    box-sizing: border-box;
+    position: absolute;
+    left: 0; right: 0; top: 0; bottom: 0;
+    margin: auto; /* 기준에서 정가운데 오도록 처리 */
+  }
+  
+  .smallMissionView a:hover figcaption{
+    opacity: 1;
+  }
+
+  .smallMissionView a:focus figcaption {
+    opacity: 0;
+  }
+
+/* 여기까지 */
+
 .smallMissionCardTitle {
     padding-top: 14px;
     padding-bottom: 15px;
@@ -99,6 +152,59 @@ html {
     background-color: #fff;
     box-shadow: 4px 4px 4px 0 rgba(0, 0, 0, 0.25);
 }
+
+/* 호버 여기부터 */
+*{ padding: 0; margin: 0; }
+li{ list-style: none; }
+
+  .smallSuccessView li{
+    float: left;
+    width: 146px; height: 146px;
+    /* margin-right: 20px; */
+  }
+  .smallSuccessView li:last-child{ margin-right: 0; }
+  
+  .smallSuccessView a{
+    display: block; /* 영역적용위해 사용 */
+    width: 100%; height: 100%;
+    overflow: hidden; /* 넘어가는 자손을 안보이게 처리 */
+    position: relative; /* figcaption의 앱솔루트 기준을 현재 요소로 변경 */
+  }
+  
+  .smallSuccessView figcaption{
+    width: 100%; height: 100%;
+    background-color: rgba(0,0,0,0.2);
+    color: #fff; text-align: center;
+    line-height: 150px;
+    font-size:10px;
+    position: absolute; /* 기본기준 : body */
+    top: 0; left: 0;
+    opacity: 0; /* 처음에 안보이게 처리 */
+    transition: 0.3s; /* 변화되는 CSS에 시간차를 줌 */
+  }
+  
+  /* 테두리 */
+  .smallSuccessView figcaption:after{
+    content: ''; /* 비워둠 */
+    display: block;
+    width: calc(100% - 15px);
+    height: calc(100% - 15px);
+    border: 1px solid #fff;
+    box-sizing: border-box;
+    position: absolute;
+    left: 0; right: 0; top: 0; bottom: 0;
+    margin: auto; /* 기준에서 정가운데 오도록 처리 */
+  }
+  
+  .smallSuccessView a:hover figcaption{
+    opacity: 1;
+  }
+
+  .smallSuccessView a:focus figcaption{
+    opacity: 0;
+  }
+
+/* 여기까지 */
 
 .smallSuccessImageMask {
     width: 146px;
@@ -416,7 +522,7 @@ html {
 .register {
     margin-left: auto;
     margin-right: auto;
-    font-family: Roboto;
+    font-family: Arial;
     margin-top: 21px;
     font-size: 20px;
     font-weight: 600;
@@ -427,7 +533,7 @@ html {
 .login {
     margin-left: auto;
     margin-right: auto;
-    font-family: Roboto;
+    font-family: Arial;
     margin-top: 21px;
     font-size: 20px;
     font-weight: 600;
@@ -480,7 +586,7 @@ button {
     /* position: absolute;
     top: 291px;
     left: 10%; */
-    font-family: Roboto;
+    font-family: Arial;
     font-size: 64px;
     font-weight: bold;
     text-align: center;
@@ -495,7 +601,7 @@ button {
     /* position: absolute;
     top: 427px;
     left: 10%; */
-    font-family: Roboto;
+    font-family: Arial;
     font-size: 64px;
     font-weight: bold;
     text-align: center;
@@ -735,7 +841,7 @@ button {
 }
 
 .mainPageTitle {
-    font-family: Roboto;
+    font-family: Arial;
     font-size: 28px;
     font-weight: 500;
     text-align: center;
@@ -752,7 +858,7 @@ button {
 
 .findOtherSpot {
     flex-grow: 0;
-    font-family: Roboto;
+    font-family: Arial;
     font-size: 12px;
     font-weight: 800;
     line-height: 1.88;
@@ -783,7 +889,7 @@ button {
 
 .findSuccess {
     flex-grow: 0;
-    font-family: Roboto;
+    font-family: Arial;
     font-size: 12px;
     font-weight: 800;
     line-height: 1.88;
@@ -809,4 +915,100 @@ button {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+}
+
+.resultPageWave {
+    padding: 40px 0 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.resultPageTitle {
+    font-family: Arial;
+    font-size: 28px;
+    font-weight: 500;
+    margin-top : 40px;
+    text-align: center;
+    color: #525252;
+    padding-bottom: 15px;
+}
+
+.resultPageServeTitle {
+    font-family: Arial;
+    font-size: 20px;
+    font-weight: 500;
+
+    text-align: center;
+    color: #afafaf;
+    padding-bottom: 30px;
+}
+
+.schoolCardGrid {
+    padding-top: 30px;
+    padding-bottom: 30px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}
+
+.AnyangCardGrid {
+    padding-top: 30px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}
+
+.collectionPageWave {
+    padding: 40px 0 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.collectionPageTitle {
+    font-family: Arial;
+    font-size: 28px;
+    font-weight: 500;
+    text-align: center;
+    color: #525252;
+    padding-bottom: 30px;
+}
+
+.schoolTitle {
+    font-family: Arial;
+    margin-left : 20px;
+    font-size: 20px;
+    font-weight: 500;
+    text-align: left;
+    color: #525252;
+    padding-bottom: 30px;
+}
+
+.schoolServeTitle {
+    font-family: Arial;
+    margin-left : 20px;
+    font-size: 18px;
+    font-weight: 500;
+    text-align: left;
+    line-height: 140%;
+    color: #525252;
+    padding-bottom: 30px;
+}
+
+.colloectionSuccess {
+    font-family: Arial;
+    margin-right : 50px;
+    font-size: 18px;
+    font-weight: 500;
+    text-align: right;
+    color: #525252;
+    padding-bottom: 30px;
+
+}
+
+.collectionLocation {
+
 }


### PR DESCRIPTION
smallMissioncard, smallSuccessCard에 마우스 올릴 시 "자세히 보기" 문구 출력
카드 별로 padding 값 다르게 적용되어 사진, 댓글 공간에 맞춰서 제작
+ 보완해야 할 점
- 메인 페이지에서 "자세히보기" 클릭 시 detailView로 정상적으로 넘어가지만
  호버 효과는 detailView 뒤로 넘어가지 않음.